### PR TITLE
Fix the toggle expand

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -171,7 +171,7 @@ class Dropdown extends Component<Props, State> {
                     ...expandedHeaderStyle,
                     ...focusedHeaderStyle,
                 }}
-                onClick={this.toggleExpanded}
+                onClick={() => this.toggleExpanded()}
             >
                 <span
                     className="dropdown-heading-value"


### PR DESCRIPTION
To fix fail to close the dropdown when dropdown is expanded and click the arrow.

Since the first parameter of onClick is event and toggleExpanded method always parses the first parameter into true when the value is not undefined , it fails to close the drop down.