### PR TITLE
Fix hover story by passing props through

### DIFF
--- a/src/stories/dropdown.js
+++ b/src/stories/dropdown.js
@@ -70,9 +70,10 @@ class ContentPanel extends Component<{}> {
     }
 }
 
-const DropdownExample = () => <Dropdown
+const DropdownExample = (props) => <Dropdown
     contentComponent={ContentPanel}
     contentProps={{}}
+    {...props}
 >
     <span>This is the header</span>
 </Dropdown>;


### PR DESCRIPTION
The open on hover story wasn't passing the shouldToggleOnHover through to the actual dropdown component.