### PR TITLE
use aria-labelledby to allow accessibility compliance

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -15,6 +15,7 @@ type Props = {
     isLoading?: boolean,
     disabled?: boolean,
     shouldToggleOnHover?: boolean
+    labelledBy?: string,
 };
 
 type State = {
@@ -128,7 +129,7 @@ class Dropdown extends Component<Props, State> {
 
     render() {
         const {expanded, hasFocus} = this.state;
-        const {children, isLoading, disabled} = this.props;
+        const {children, isLoading, disabled, labelledBy} = this.props;
 
         const expandedHeaderStyle = expanded
             ? styles.dropdownHeaderExpanded
@@ -155,6 +156,7 @@ class Dropdown extends Component<Props, State> {
             className="dropdown"
             tabIndex="0"
             role="combobox"
+            aria-labelledby={labelledBy}
             aria-expanded={expanded}
             aria-readonly="true"
             aria-disabled={disabled}

--- a/src/index.js
+++ b/src/index.js
@@ -12,19 +12,24 @@
  * - valueRenderer: A fn to support overriding the message in the component
  * - isLoading: Show a loading indicator
  */
-import React, { Component } from "react";
+import React, {Component} from 'react';
 
-import Dropdown from "./dropdown.js";
-import SelectPanel from "./select-panel.js";
-import getString from "./get-string.js";
+import Dropdown from './dropdown.js';
+import SelectPanel from './select-panel.js';
+import getString from './get-string.js';
 
-import type { Option } from "./select-item.js";
+import type {
+    Option,
+} from './select-item.js';
 
 type Props = {
     options: Array<Option>,
     selected: Array<any>,
     onSelectedChanged?: (selected: Array<any>) => void,
-    valueRenderer?: (selected: Array<any>, options: Array<Option>) => string,
+    valueRenderer?: (
+        selected: Array<any>,
+        options: Array<Option>
+    ) => string,
     ItemRenderer?: Function,
     selectAllLabel?: string,
     isLoading?: boolean,
@@ -33,24 +38,23 @@ type Props = {
     shouldToggleOnHover: boolean,
     hasSelectAll: boolean,
     filterOptions?: (options: Array<Option>, filter: string) => Array<Option>,
-    overrideStrings?: { [string]: string },
+    overrideStrings?: {[string]: string},
     labelledBy: string
 };
 
 class MultiSelect extends Component<Props> {
     static defaultProps = {
         hasSelectAll: true,
-        shouldToggleOnHover: false
-    };
+        shouldToggleOnHover: false,
+    }
 
     getSelectedText() {
-        const { options, selected } = this.props;
+        const {options, selected} = this.props;
 
-        const selectedOptions = selected.map(s =>
-            options.find(o => o.value === s)
-        );
+        const selectedOptions = selected
+            .map(s => options.find(o => o.value === s));
 
-        const selectedLabels = selectedOptions.map(s => (s ? s.label : ""));
+        const selectedLabels = selectedOptions.map(s => s ? s.label : "");
 
         return selectedLabels.join(", ");
     }
@@ -60,7 +64,7 @@ class MultiSelect extends Component<Props> {
             options,
             selected,
             valueRenderer,
-            overrideStrings
+            overrideStrings,
         } = this.props;
 
         const noneSelected = selected.length === 0;
@@ -69,29 +73,25 @@ class MultiSelect extends Component<Props> {
         const customText = valueRenderer && valueRenderer(selected, options);
 
         if (noneSelected) {
-            return (
-                <span style={styles.noneSelected}>
-                    {customText ||
-                        getString("selectSomeItems", overrideStrings)}
-                </span>
-            );
+            return <span style={styles.noneSelected}>
+                {customText || getString("selectSomeItems", overrideStrings)}
+            </span>;
         }
 
         if (customText) {
             return <span>{customText}</span>;
         }
 
-        return (
-            <span>
-                {allSelected
-                    ? getString("allItemsAreSelected", overrideStrings)
-                    : this.getSelectedText()}
-            </span>
-        );
+        return <span>
+            {allSelected
+                ? getString("allItemsAreSelected", overrideStrings)
+                : this.getSelectedText()
+            }
+        </span>;
     }
 
     handleSelectedChanged = (selected: Array<any>) => {
-        const { onSelectedChanged, disabled } = this.props;
+        const {onSelectedChanged, disabled} = this.props;
 
         if (disabled) {
             return;
@@ -100,7 +100,7 @@ class MultiSelect extends Component<Props> {
         if (onSelectedChanged) {
             onSelectedChanged(selected);
         }
-    };
+    }
 
     render() {
         const {
@@ -115,42 +115,40 @@ class MultiSelect extends Component<Props> {
             shouldToggleOnHover,
             hasSelectAll,
             overrideStrings,
-            labelledBy
+            labelledBy,
         } = this.props;
 
-        return (
-            <div className="multi-select">
-                <Dropdown
-                    isLoading={isLoading}
-                    contentComponent={SelectPanel}
-                    shouldToggleOnHover={shouldToggleOnHover}
-                    contentProps={{
-                        ItemRenderer,
-                        options,
-                        selected,
-                        hasSelectAll,
-                        selectAllLabel,
-                        onSelectedChanged: this.handleSelectedChanged,
-                        disabled,
-                        disableSearch,
-                        filterOptions,
-                        overrideStrings
-                    }}
-                    disabled={disabled}
-                    labelledBy={labelledBy}
-                >
-                    {this.renderHeader()}
-                </Dropdown>
-            </div>
-        );
+        return <div className="multi-select">
+            <Dropdown
+                isLoading={isLoading}
+                contentComponent={SelectPanel}
+                shouldToggleOnHover={shouldToggleOnHover}
+                contentProps={{
+                    ItemRenderer,
+                    options,
+                    selected,
+                    hasSelectAll,
+                    selectAllLabel,
+                    onSelectedChanged: this.handleSelectedChanged,
+                    disabled,
+                    disableSearch,
+                    filterOptions,
+                    overrideStrings,
+                }}
+                disabled={disabled}
+                labelledBy={labelledBy}
+            >
+                {this.renderHeader()}
+            </Dropdown>
+        </div>;
     }
 }
 
 const styles = {
     noneSelected: {
-        color: "#aaa"
-    }
+        color: "#aaa",
+    },
 };
 
 export default MultiSelect;
-export { Dropdown };
+export {Dropdown};

--- a/src/index.js
+++ b/src/index.js
@@ -12,24 +12,19 @@
  * - valueRenderer: A fn to support overriding the message in the component
  * - isLoading: Show a loading indicator
  */
-import React, {Component} from 'react';
+import React, { Component } from "react";
 
-import Dropdown from './dropdown.js';
-import SelectPanel from './select-panel.js';
-import getString from './get-string.js';
+import Dropdown from "./dropdown.js";
+import SelectPanel from "./select-panel.js";
+import getString from "./get-string.js";
 
-import type {
-    Option,
-} from './select-item.js';
+import type { Option } from "./select-item.js";
 
 type Props = {
     options: Array<Option>,
     selected: Array<any>,
     onSelectedChanged?: (selected: Array<any>) => void,
-    valueRenderer?: (
-        selected: Array<any>,
-        options: Array<Option>
-    ) => string,
+    valueRenderer?: (selected: Array<any>, options: Array<Option>) => string,
     ItemRenderer?: Function,
     selectAllLabel?: string,
     isLoading?: boolean,
@@ -38,22 +33,24 @@ type Props = {
     shouldToggleOnHover: boolean,
     hasSelectAll: boolean,
     filterOptions?: (options: Array<Option>, filter: string) => Array<Option>,
-    overrideStrings?: {[string]: string}
+    overrideStrings?: { [string]: string },
+    labelledBy: string
 };
 
 class MultiSelect extends Component<Props> {
     static defaultProps = {
         hasSelectAll: true,
-        shouldToggleOnHover: false,
-    }
+        shouldToggleOnHover: false
+    };
 
     getSelectedText() {
-        const {options, selected} = this.props;
+        const { options, selected } = this.props;
 
-        const selectedOptions = selected
-            .map(s => options.find(o => o.value === s));
+        const selectedOptions = selected.map(s =>
+            options.find(o => o.value === s)
+        );
 
-        const selectedLabels = selectedOptions.map(s => s ? s.label : "");
+        const selectedLabels = selectedOptions.map(s => (s ? s.label : ""));
 
         return selectedLabels.join(", ");
     }
@@ -63,7 +60,7 @@ class MultiSelect extends Component<Props> {
             options,
             selected,
             valueRenderer,
-            overrideStrings,
+            overrideStrings
         } = this.props;
 
         const noneSelected = selected.length === 0;
@@ -72,25 +69,29 @@ class MultiSelect extends Component<Props> {
         const customText = valueRenderer && valueRenderer(selected, options);
 
         if (noneSelected) {
-            return <span style={styles.noneSelected}>
-                {customText || getString("selectSomeItems", overrideStrings)}
-            </span>;
+            return (
+                <span style={styles.noneSelected}>
+                    {customText ||
+                        getString("selectSomeItems", overrideStrings)}
+                </span>
+            );
         }
 
         if (customText) {
             return <span>{customText}</span>;
         }
 
-        return <span>
-            {allSelected
-                ? getString("allItemsAreSelected", overrideStrings)
-                : this.getSelectedText()
-            }
-        </span>;
+        return (
+            <span>
+                {allSelected
+                    ? getString("allItemsAreSelected", overrideStrings)
+                    : this.getSelectedText()}
+            </span>
+        );
     }
 
     handleSelectedChanged = (selected: Array<any>) => {
-        const {onSelectedChanged, disabled} = this.props;
+        const { onSelectedChanged, disabled } = this.props;
 
         if (disabled) {
             return;
@@ -99,7 +100,7 @@ class MultiSelect extends Component<Props> {
         if (onSelectedChanged) {
             onSelectedChanged(selected);
         }
-    }
+    };
 
     render() {
         const {
@@ -114,38 +115,42 @@ class MultiSelect extends Component<Props> {
             shouldToggleOnHover,
             hasSelectAll,
             overrideStrings,
+            labelledBy
         } = this.props;
 
-        return <div className="multi-select">
-            <Dropdown
-                isLoading={isLoading}
-                contentComponent={SelectPanel}
-                shouldToggleOnHover={shouldToggleOnHover}
-                contentProps={{
-                    ItemRenderer,
-                    options,
-                    selected,
-                    hasSelectAll,
-                    selectAllLabel,
-                    onSelectedChanged: this.handleSelectedChanged,
-                    disabled,
-                    disableSearch,
-                    filterOptions,
-                    overrideStrings,
-                }}
-                disabled={disabled}
-            >
-                {this.renderHeader()}
-            </Dropdown>
-        </div>;
+        return (
+            <div className="multi-select">
+                <Dropdown
+                    isLoading={isLoading}
+                    contentComponent={SelectPanel}
+                    shouldToggleOnHover={shouldToggleOnHover}
+                    contentProps={{
+                        ItemRenderer,
+                        options,
+                        selected,
+                        hasSelectAll,
+                        selectAllLabel,
+                        onSelectedChanged: this.handleSelectedChanged,
+                        disabled,
+                        disableSearch,
+                        filterOptions,
+                        overrideStrings
+                    }}
+                    disabled={disabled}
+                    labelledBy={labelledBy}
+                >
+                    {this.renderHeader()}
+                </Dropdown>
+            </div>
+        );
     }
 }
 
 const styles = {
     noneSelected: {
-        color: "#aaa",
-    },
+        color: "#aaa"
+    }
 };
 
 export default MultiSelect;
-export {Dropdown};
+export { Dropdown };


### PR DESCRIPTION
Previously, without wrapping the react-multi-select in a label a screen reader would not associate the label with this role='combobox'. When you did wrap the component with a label, it would cause issue for a screen reader on the individual item level reading.

This should fix the issue.