### PR TITLE
Widen react peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-runtime": "^6.26.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "fuzzy-match-utils": "^1.2.0"


### PR DESCRIPTION
Hi, I know this project has reached staleness. Nevertheless we use it daily and I am trying to get rid of warnings. Would it be possible to accept a wider range of React versions ? :smiley: 